### PR TITLE
Update slide 8.4

### DIFF
--- a/index.html
+++ b/index.html
@@ -467,8 +467,7 @@
               <li>Other popular langauges include:</li>
               <ul>
                 <li>Perl</li>
-                <li>.NET</li>
-                <li>Visual Basic</li>
+                <li>Visual Basic .NET</li>
                 <li>R</li>
                 <li>Swift</li>
               </ul>


### PR DESCRIPTION
remove ".NET" listing as a language and updated "Visual Basic" (not supported) to "Visual Basic .NET"
